### PR TITLE
chore: release `1.0.0-beta8` to homebrew

### DIFF
--- a/Formula/elide.rb
+++ b/Formula/elide.rb
@@ -1,17 +1,16 @@
 class Elide < Formula
   desc "Fast polyglot runtime for JavaScript, TypeScript, and Python"
   homepage "https://elide.dev"
-  version "1.0.0-beta7"
+  version "1.0.0-beta8"
   license "MIT"
   
   on_macos do
     on_arm do
       url "https://elide.zip/cli/v1/snapshot/darwin-aarch64/#{version}/elide.txz"
-      sha256 "130e0efcb6f253eac9527dac150d47b34b9c0be7c4f43660fe79f33d007cbc85"
+      sha256 "061f5035690e4d1859cbf49cb1559958a2d0b0b7f17f2a257583ce56d5c123ba"
     end
     on_intel do
       # macOS Intel not available in this version
-      # Will be available in future releases
       raise "Elide #{version} does not support macOS Intel. Only ARM64 (Apple Silicon) is supported."
     end
   end
@@ -19,11 +18,11 @@ class Elide < Formula
   on_linux do
     on_arm do
       url "https://elide.zip/cli/v1/snapshot/linux-aarch64/#{version}/elide.tgz"
-      sha256 "e43beb097b06ffbcada13f595cda532c2e81ae5b8001785253d9926729392b50"
+      sha256 "f5bdc8845726cb32564cd8ea97c286e8c5ef243662bb52480ff553c29c7231d7"
     end
     on_intel do
       url "https://elide.zip/cli/v1/snapshot/linux-amd64/#{version}/elide.tgz"
-      sha256 "2cbd9d45f5904390b303a1963379cc3e68591cf09aa875bff260cf1fb45bfe38"
+      sha256 "a5430b7e398c12b66fc6a13a1ac3fd1a7622db48b0a312ccce6232aafa40d23d"
     end
   end
   


### PR DESCRIPTION
Releases `1.0.0-beta8`, from elide-dev/elide#1551.