### PR TITLE
chore: release `1.0.0-beta9` to homebrew

### DIFF
--- a/Formula/elide.rb
+++ b/Formula/elide.rb
@@ -1,13 +1,13 @@
 class Elide < Formula
   desc "Fast polyglot runtime for JavaScript, TypeScript, and Python"
   homepage "https://elide.dev"
-  version "1.0.0-beta8"
+  version "1.0.0-beta9"
   license "MIT"
   
   on_macos do
     on_arm do
       url "https://elide.zip/cli/v1/snapshot/darwin-aarch64/#{version}/elide.txz"
-      sha256 "061f5035690e4d1859cbf49cb1559958a2d0b0b7f17f2a257583ce56d5c123ba"
+      sha256 "47d4ca73f211cc5e70e0a8b857a02c5bb4192633f96927509a8b4901ffee997c"
     end
     on_intel do
       # macOS Intel not available in this version
@@ -18,11 +18,11 @@ class Elide < Formula
   on_linux do
     on_arm do
       url "https://elide.zip/cli/v1/snapshot/linux-aarch64/#{version}/elide.tgz"
-      sha256 "f5bdc8845726cb32564cd8ea97c286e8c5ef243662bb52480ff553c29c7231d7"
+      sha256 "34c3aed8a9d3ac243ea62100c8ee1e17ce2d6e218f578626916feb7feb9b84ef"
     end
     on_intel do
       url "https://elide.zip/cli/v1/snapshot/linux-amd64/#{version}/elide.tgz"
-      sha256 "a5430b7e398c12b66fc6a13a1ac3fd1a7622db48b0a312ccce6232aafa40d23d"
+      sha256 "26eb0e66d08d97911db9d021051f87a448015a48ddfebc36e7f76f6a02af263c"
     end
   end
   


### PR DESCRIPTION
Bump and release at `1.0.0-beta9`